### PR TITLE
BugFix: Actually Call SaveSelf() on OC.saveEntity. A mistake?

### DIFF
--- a/LORM/obc.lua
+++ b/LORM/obc.lua
@@ -388,7 +388,7 @@ function ObjectCordinator.new(self,NS,DB)
                         --self[p] = self[p]
                     --end
                 end
-                return SaveSelf
+                return SaveSelf()
 
             end,
             [entity_state.modified]=function()


### PR DESCRIPTION
Hi, thank you for your great work, I find your ORM very useful!

However, I think I found a bug. I started integrating the library using a very simple model with one text field, which didn't save properly to the database unless it had a foreign key, any, linking to whatever other field. Few hours later... having gone through most of your code I think it all boils down to actually never calling `SaveSelf` in `OC.saveEntity`. This is probably just a typo, which never caused a bug because the Classroom app you provided has FKs everywhere. Can you have a look? I verified this on my models and this does save the issue but I don't know if it won't break other things.

Thanks. Let me know if you need more details. I can provide models and so on though this should not be necessary.
